### PR TITLE
更新了"en.json"的链接

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Update Projects Source Json
-        run: wget https://github.com/foundryvtt/dnd5e/raw/master/lang/en.json -O ./.github/en.json
+        run: wget https://github.com/foundryvtt/dnd5e/blob/master/lang/en.json -O ./.github/en.json
         
       - name: Add & Commit
         uses: EndBug/add-and-commit@v7.2.1


### PR DESCRIPTION
旧的链接失效了，将“update.yml”中的链接替换为了当前官方的“en.json”链接。